### PR TITLE
Add support for darwin

### DIFF
--- a/swig/prologue.lisp
+++ b/swig/prologue.lisp
@@ -1,6 +1,7 @@
 (in-package #:cl-isl)
 
 (cffi:define-foreign-library libisl
+  (:darwin (:or "libisl.dylib" "libisl.22.dylib"))
   (:unix (:or "libisl.so" "libisl.so.22"))
   (t (:default "libisl")))
 


### PR DESCRIPTION
When trying to load the library on OSX machine it'll try to get the Unix `.so` libraries when it should be the `.dylib` ones.